### PR TITLE
FIX: Don't assume SS4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	],
 	"require":
 	{
-		"silverstripe/framework": "*",
+		"silverstripe/framework": "^3.0",
 		"hafriedlander/phockito": "*"
 	}
 }


### PR DESCRIPTION
Major versions won't automatically work, and so I've amended the composer requirements
not to allow SS4.

This will also ensure that addons.silverstripe.org correctly reports which modules
work with SS4.